### PR TITLE
Fix example in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See also the [example config](borgbackup.yml)
 
 # Examples
 
-Create a backup and prune archives according to the config settings:
+Create a backup according to the config settings:
 
 ```
 borgwrap -c borgbackup.yaml create --stats


### PR DESCRIPTION
Since 5aff18ad4e661ab3f724bc7132ce7e7c6717ef3f no pruning is done by default.